### PR TITLE
投稿詳細ページ、編集機能を作成

### DIFF
--- a/app/controllers/api/arrangements_controller.rb
+++ b/app/controllers/api/arrangements_controller.rb
@@ -36,8 +36,8 @@ module Api
     private
 
     def arrangement_params
-      params.dig(:data, :attributes, :images).map! { |image| create_uploadedfile(image) }
-      params[:data].require(:attributes).permit(:title, :context, { images: [] })
+      params[:arrangement][:images].map! { |image| create_uploadedfile(image) }
+      params.require(:arrangement).permit(:title, :context, images: [])
     end
   end
 end

--- a/app/controllers/api/arrangements_controller.rb
+++ b/app/controllers/api/arrangements_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ArrangementsController < ApplicationController
-    skip_before_action :require_login, only: %i[index]
+    skip_before_action :require_login, only: %i[index show]
 
     def index
       pagy, arrangements = pagy(Arrangement.preload(:user), items: 20)
@@ -20,6 +20,27 @@ module Api
       else
         render json: arrangement.errors.full_messages, status: :bad_request
       end
+    end
+
+    def show
+      arrangement = Arrangement.find(params[:id])
+      options = {
+        include: %i[user],
+        fields: { arrangement: %i[title context images user], user: %i[nickname avatar] }
+      }
+      json_string = ArrangementSerializer.new(arrangement, options)
+      render json: json_string
+    end
+
+    def update
+      arrangement = Arrangement.find(params[:arrangement][:id])
+      render head 400 unless arrangement.update(arrangement_params)
+      options = {
+        include: %i[user],
+        fields: { arrangement: %i[title context images user], user: %i[nickname avatar] }
+      }
+      json_string = ArrangementSerializer.new(arrangement, options)
+      render json: json_string
     end
 
     def mine

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -10,15 +10,15 @@ module Api
     end
 
     def password
-      current_user.password_confirmation = params[:data][:password_confirmation]
-      current_user.change_password(params[:data][:password]) ? head(200) : head(400)
+      current_user.password_confirmation = params[:password_confirmation]
+      current_user.change_password(params[:password]) ? head(200) : head(400)
     end
 
     private
 
     def user_params
-      params[:data][:user][:avatar] = create_uploadedfile(params[:data][:user][:avatar])
-      params[:data].require(:user).permit(:nickname, :email, :avatar)
+      params[:user][:avatar] = create_uploadedfile(params[:user][:avatar])
+      params.require(:user).permit(:nickname, :email, :avatar)
     end
   end
 end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -3,7 +3,7 @@ module Api
     skip_before_action :require_login, only: %i[create]
 
     def create
-      user = login(params[:data][:email], params[:data][:password])
+      user = login(params[:email], params[:password])
       if user
         json_string = UserSerializer.new(user).serializable_hash
         render json: json_string

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -21,7 +21,7 @@ module Api
     private
 
     def user_params
-      params[:data].require(:attributes).permit(:nickname, :email, :password, :password_confirmation)
+      params.require(:user).permit(:nickname, :email, :password, :password_confirmation)
     end
   end
 end

--- a/app/frontend/components/global/TheHeader.vue
+++ b/app/frontend/components/global/TheHeader.vue
@@ -17,10 +17,12 @@
               </v-avatar>
             </v-btn>
           </template>
-          <v-list dense flat>
+          <v-list id="header-menu-list" dense flat>
             <v-list-item text plain :to="{ name: 'UserProfile' }">マイページ</v-list-item>
             <v-list-item text>お気に入り一覧</v-list-item>
-            <v-list-item text @click="logoutFunction"> ログアウト </v-list-item>
+            <v-list-item id="header-logout-button" text @click="logoutFunction">
+              ログアウト
+            </v-list-item>
           </v-list>
         </v-menu>
       </template>
@@ -46,12 +48,12 @@ export default {
     logoutFunction() {
       this.logoutUser().then((res) => {
         if (res) {
-          this.$router.go({ path: this.$router.currentRoute.path });
           this.fetchSnackbarData({
             msg: 'ログアウトしました',
             color: 'success',
             isShow: true,
           });
+          this.$router.go();
         } else {
           this.fetchSnackbarData({
             msg: 'ログアウトに失敗しました',

--- a/app/frontend/components/global/TheHeader.vue
+++ b/app/frontend/components/global/TheHeader.vue
@@ -44,7 +44,7 @@ export default {
     // 新規登録後、アバターの画像が反映されないのに対応する為
     $route(to, from) {
       if (from.name === 'UserRegister' && to.name === 'TopPage') {
-        if (this.authUser.data) {
+        if (this.authUser?.data) {
           document.querySelector('#header-avatar').src = this.authUser.data.avatar;
         }
       }

--- a/app/frontend/components/global/TheHeader.vue
+++ b/app/frontend/components/global/TheHeader.vue
@@ -25,10 +25,10 @@
         </v-menu>
       </template>
       <template v-else>
-        <v-btn plain text xLarge :to="{ name: 'UserRegister' }"> 新規登録 </v-btn>
-        <v-btn class="hidden-sm-and-down" plain text xLarge :to="{ name: 'UserLogin' }">
-          ログイン
+        <v-btn class="hidden-sm-and-down" plain text xLarge :to="{ name: 'UserRegister' }">
+          新規登録
         </v-btn>
+        <v-btn plain text xLarge :to="{ name: 'UserLogin' }"> ログイン </v-btn>
       </template>
     </v-app-bar>
   </div>

--- a/app/frontend/components/global/TheHeader.vue
+++ b/app/frontend/components/global/TheHeader.vue
@@ -40,16 +40,6 @@ export default {
   computed: {
     ...mapGetters('users', ['authUser']),
   },
-  watch: {
-    // 新規登録後、アバターの画像が反映されないのに対応する為
-    $route(to, from) {
-      if (from.name === 'UserRegister' && to.name === 'TopPage') {
-        if (this.authUser?.data) {
-          document.querySelector('#header-avatar').src = this.authUser.data.avatar;
-        }
-      }
-    },
-  },
   methods: {
     ...mapActions('users', ['logoutUser']),
     ...mapActions('snackbars', ['fetchSnackbarData']),

--- a/app/frontend/components/global/TheSnackbar.vue
+++ b/app/frontend/components/global/TheSnackbar.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <v-snackbar
+      id="global-snackbar"
       v-model="isVisiable"
       top
       right

--- a/app/frontend/components/pages/ArrangementNew.vue
+++ b/app/frontend/components/pages/ArrangementNew.vue
@@ -4,84 +4,12 @@
       <v-col cols="12" sm="7" class="pt-16 mx-auto">
         <v-card class="pa-4" color="grey lighten-5">
           <div class="text-h6 pt-8 px-8 mb-5 text-center font-weight-black">新規投稿</div>
-          <v-img v-show="isPreview" class="mb-5" :src="previewImage" contain height="300" />
-          <ValidationObserver v-slot="{ handleSubmit }">
-            <v-card-text>
-              <ValidationProvider
-                v-slot="{ errors }"
-                ref="fileForm"
-                name="投稿写真"
-                mode="change"
-                :rules="{ required: true, ext: ['jpg', 'jpeg', 'png', 'gif'], size: 10240 }"
-              >
-                <v-file-input
-                  id="arrangement-images"
-                  label="投稿写真"
-                  color="black"
-                  clearable
-                  hint="有効なファイル形式はjpg jpeg png gifです"
-                  prependIcon
-                  prependInnerIcon="mdi-camera"
-                  persistentHint
-                  :errorMessages="errors"
-                  @change="handleFileChange"
-                >
-                  <template #selection="{ text }">
-                    <v-chip small label color="grey lighten-1">
-                      {{ text }}
-                    </v-chip>
-                  </template>
-                </v-file-input>
-              </ValidationProvider>
-              <ValidationProvider
-                v-slot="{ errors }"
-                :rules="{ required: true, max: 30 }"
-                name="タイトル"
-              >
-                <v-text-field
-                  id="arrangement-title"
-                  v-model="arrangement.title"
-                  class="mb-6"
-                  type="text"
-                  label="タイトル"
-                  clearable
-                  color="black"
-                  counter="30"
-                  :errorMessages="errors"
-                />
-              </ValidationProvider>
-              <ValidationProvider
-                v-slot="{ errors }"
-                :rules="{ required: true, max: 1000 }"
-                name="投稿内容"
-              >
-                <v-textarea
-                  id="arrangement-context"
-                  v-model="arrangement.context"
-                  label="投稿内容"
-                  outlined
-                  autoGrow
-                  clearable
-                  color="black"
-                  counter="1000"
-                  :errorMessages="errors"
-                />
-              </ValidationProvider>
-            </v-card-text>
-            <v-card-actions class="d-flex justify-center">
-              <v-btn
-                style="color: white"
-                color="#ff5252"
-                xLarge
-                :loading="isLoading"
-                :disabled="isLoading"
-                @click="handleSubmit(createArrangement)"
-              >
-                <v-icon class="mr-1">mdi-send</v-icon>
-                投稿する
-              </v-btn>
-            </v-card-actions>
-          </ValidationObserver>
+          <ArrangementNewForm
+            v-bind.sync="arrangement"
+            :isLoadng="isLoading"
+            @createArrangement="createArrangement"
+            @uploadFile="uploadFile"
+          />
         </v-card>
       </v-col>
     </v-row>
@@ -89,10 +17,13 @@
 </template>
 
 <script>
-import Jimp from 'jimp/es';
 import { mapActions } from 'vuex';
+import ArrangementNewForm from '../parts/forms/ArrangementNewForm';
 
 export default {
+  components: {
+    ArrangementNewForm,
+  },
   data() {
     return {
       arrangement: {
@@ -100,8 +31,6 @@ export default {
         context: '',
         images: [],
       },
-      previewImage: '',
-      isPreview: false,
       isLoading: false,
     };
   },
@@ -129,27 +58,8 @@ export default {
           console.log(error);
         });
     },
-    async handleFileChange(value) {
-      const result = await this.$refs.fileForm.validate(value);
-      if (result.valid) {
-        const imageURL = URL.createObjectURL(value);
-        Jimp.read(imageURL)
-          .then((image) => {
-            image.cover(300, 300).getBase64(Jimp.MIME_PNG, (err, src) => {
-              this.arrangement.images.splice(0, 1, src);
-              this.isPreview = true;
-              this.previewImage = src;
-            });
-            URL.revokeObjectURL(imageURL);
-          })
-          .catch((error) => {
-            alert('アップロードに失敗しました');
-            console.log(error);
-          });
-      } else {
-        this.isPreview = false;
-        this.previewImage = '';
-      }
+    uploadFile(src) {
+      this.arrangement.images.splice(0, 1, src);
     },
   },
 };

--- a/app/frontend/components/pages/ArrangementShow.vue
+++ b/app/frontend/components/pages/ArrangementShow.vue
@@ -1,0 +1,133 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" sm="6" class="pt-16 mx-auto">
+        <v-sheet
+          :id="`arrangement-${arrangement.id}`"
+          height="100%"
+          width="80%"
+          color="#eeeeee"
+          elevation="1"
+        >
+          <v-img
+            v-for="(image, $imageIndex) in arrangement.images"
+            :key="$imageIndex"
+            :src="image"
+          />
+          <v-card-title class="mb-4">
+            <h4 class="text-subtitle-1 font-weight-bold">{{ arrangement.title }}</h4>
+          </v-card-title>
+          <v-card-subtitle class="d-flex">
+            <v-avatar size="25" class="mr-4">
+              <img :src="user.avatar" />
+            </v-avatar>
+            <h4 class="text-subtitle-1">
+              {{ user.nickname }}
+            </h4>
+            <v-spacer />
+            <v-btn @click.stop="displayArrangementEditDialog">編集</v-btn>
+          </v-card-subtitle>
+          <v-card-text>
+            <v-sheet class="pa-5" :rounded="true" outlined color="#FAFAFA">
+              <pre class="text-body-1" width="100%">{{ arrangement.context }}</pre>
+            </v-sheet>
+          </v-card-text>
+        </v-sheet>
+        <ArrangementEditForm
+          v-if="editArrangementActed"
+          :isShow="editArrangementDialogDisplayed"
+          v-bind.sync="arrangementEdit"
+          @uploadFile="uploadFile"
+          @closeDialog="closeEditArrangement"
+          @updateArrangement="updateArrangement"
+        />
+      </v-col>
+      <v-col cols="12" sm="6"></v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+import Jimp from 'jimp/es';
+import ArrangementEditForm from '../parts/forms/ArrangementEditForm';
+
+export default {
+  components: {
+    ArrangementEditForm,
+  },
+  data() {
+    return {
+      arrangement: {},
+      user: {},
+      arrangementEdit: {},
+      editArrangementDialogDisplayed: false,
+      editArrangementActed: false,
+    };
+  },
+  computed: {
+    ...mapGetters('users', ['authUser']),
+  },
+  created() {
+    this.fetchArrangement();
+  },
+  methods: {
+    ...mapActions('snackbars', ['fetchSnackbarData']),
+    fetchArrangement() {
+      this.$devour.find('arrangement', this.$route.params.id).then((res) => {
+        this.arrangement = res.data;
+        this.user = res.data.user;
+      });
+    },
+    displayArrangementEditDialog() {
+      this.initArrangement();
+      this.handleShowEditArrangement();
+      this.editArrangementActed = true;
+    },
+    closeEditArrangement() {
+      this.handleShowEditArrangement();
+    },
+    handleShowEditArrangement() {
+      this.editArrangementDialogDisplayed = !this.editArrangementDialogDisplayed;
+    },
+    initArrangement() {
+      this.arrangementEdit = { ...this.arrangement, images: [...this.arrangement.images] };
+      Jimp.read(this.arrangementEdit.images[0]).then((image) => {
+        image.getBase64(Jimp.MIME_PNG, (err, src) => {
+          this.arrangementEdit.images.splice(0, 1, src);
+        });
+      });
+    },
+    uploadFile(src) {
+      this.arrangementEdit.images.splice(0, 1, src);
+    },
+    updateArrangement() {
+      this.$devour
+        .update('arrangement', this.arrangementEdit)
+        .then((res) => {
+          this.arrangement = res.data;
+          this.closeEditArrangement();
+          this.fetchSnackbarData({
+            msg: '投稿を更新しました',
+            color: 'success',
+            isShow: true,
+          });
+        })
+        .catch((err) => {
+          this.fetchSnackbarData({
+            msg: '投稿を更新できませんでした',
+            color: 'error',
+            isShow: true,
+          });
+          console.log(err);
+        });
+    },
+  },
+};
+</script>
+
+<style scoped>
+pre {
+  white-space: pre-wrap;
+}
+</style>

--- a/app/frontend/components/pages/ArrangementShow.vue
+++ b/app/frontend/components/pages/ArrangementShow.vue
@@ -25,7 +25,9 @@
               {{ user.nickname }}
             </h4>
             <v-spacer />
-            <v-btn @click.stop="displayArrangementEditDialog">編集</v-btn>
+            <template v-if="authUser.id === user.id">
+              <v-btn @click.stop="displayArrangementEditDialog">編集</v-btn>
+            </template>
           </v-card-subtitle>
           <v-card-text>
             <v-sheet class="pa-5" :rounded="true" outlined color="#FAFAFA">

--- a/app/frontend/components/pages/Arrangements.vue
+++ b/app/frontend/components/pages/Arrangements.vue
@@ -1,0 +1,7 @@
+<template>
+  <router-view />
+</template>
+
+<script>
+export default {};
+</script>

--- a/app/frontend/components/pages/TopPage.vue
+++ b/app/frontend/components/pages/TopPage.vue
@@ -3,7 +3,9 @@
     <WelcomeDialog :dialog="welcomeDialogDisplayed" @close-dialog="closeWelcomeDialog" />
     <v-row>
       <v-col v-for="(arrangement, $index) in arrangements" :key="$index" cols="12" sm="4" md="4">
-        <ArrangementSummary :arrangement="arrangement" :user="arrangement.user" />
+        <router-link :to="{ name: 'ArrangementShow', params: { id: arrangement.id } }">
+          <ArrangementSummary :arrangement="arrangement" :user="arrangement.user" />
+        </router-link>
       </v-col>
       <infinite-loading
         v-if="pagy.isActioned"

--- a/app/frontend/components/pages/UserProfile.vue
+++ b/app/frontend/components/pages/UserProfile.vue
@@ -103,6 +103,7 @@ export default {
   },
   data() {
     return {
+      authUserProfile: {},
       authUserEdit: {},
       arrangements: [],
       password: '',
@@ -207,12 +208,12 @@ export default {
           { password: this.password, password_confirmation: this.password_confirmation }
         )
         .then(() => {
-          this.handleShowEditPassword();
           this.fetchSnackbarData({
             msg: 'パスワードを更新しました',
             color: 'success',
             isShow: true,
           });
+          this.closeEditPasswordDialog();
         })
         .catch((err) => {
           this.fetchSnackbarData({

--- a/app/frontend/components/pages/UserProfile.vue
+++ b/app/frontend/components/pages/UserProfile.vue
@@ -66,7 +66,9 @@
               sm="4"
               md="4"
             >
-              <ArrangementSummary :arrangement="arrangement" :user="authUser" />
+              <router-link :to="{ name: 'ArrangementShow', params: { id: arrangement.id } }">
+                <ArrangementSummary :arrangement="arrangement" :user="authUser" />
+              </router-link>
             </v-col>
             <infinite-loading
               v-if="pagy.isActioned"

--- a/app/frontend/components/parts/WelcomeDialog.vue
+++ b/app/frontend/components/parts/WelcomeDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog :value="dialog" maxWidth="630" @click:outside="$emit('close-dialog')">
-    <v-card>
+    <v-card id="welcome-dialog">
       <v-card-title class="headline grey lighten-2 d-flex justify-center">
         <span style="color: #d32f2f">ARRANGY</span>へようこそ
       </v-card-title>

--- a/app/frontend/components/parts/cards/ArrangementSummary.vue
+++ b/app/frontend/components/parts/cards/ArrangementSummary.vue
@@ -1,11 +1,6 @@
 <template>
   <v-sheet :id="`arrangement-${arrangement.id}`" height="100%" color="#eeeeee">
-    <v-img
-      v-for="(image, $imageIndex) in arrangement.images"
-      :key="$imageIndex"
-      :src="image"
-      height="300"
-    />
+    <v-img v-for="(image, $imageIndex) in arrangement.images" :key="$imageIndex" :src="image" />
     <v-card-title class="mb-4">
       <h4 class="text-subtitle-1 font-weight-bold">{{ arrangement.title }}</h4>
     </v-card-title>

--- a/app/frontend/components/parts/formInputs/ContextField.vue
+++ b/app/frontend/components/parts/formInputs/ContextField.vue
@@ -1,0 +1,33 @@
+<template>
+  <ValidationProvider v-slot="{ errors }" :rules="rules" name="投稿内容">
+    <v-textarea
+      id="arrangement-context"
+      label="投稿内容"
+      outlined
+      autoGrow
+      clearable
+      color="black"
+      counter="1000"
+      :errorMessages="errors"
+      :value="context"
+      @input="$emit('input', $event)"
+    />
+  </ValidationProvider>
+</template>
+
+<script>
+export default {
+  props: {
+    context: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    rules: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+  },
+};
+</script>

--- a/app/frontend/components/parts/formInputs/ImagesField.vue
+++ b/app/frontend/components/parts/formInputs/ImagesField.vue
@@ -16,7 +16,7 @@
       prependInnerIcon="mdi-camera"
       persistentHint
       :errorMessages="errors"
-      @change="handleFileChange"
+      @change="$emit('uploadFile', $event)"
     >
       <template #selection="{ text }">
         <v-chip small label color="grey lighten-1">
@@ -28,36 +28,11 @@
 </template>
 
 <script>
-import Jimp from 'jimp/es';
-
 export default {
   props: {
     rules: {
       type: Object,
       required: true,
-    },
-  },
-  methods: {
-    async handleFileChange(value) {
-      const result = await this.$refs.fileForm.validate(value);
-      if (result.valid) {
-        const imageURL = URL.createObjectURL(value);
-        Jimp.read(imageURL)
-          .then((image) => {
-            image.cover(300, 300).getBase64(Jimp.MIME_PNG, (err, src) => {
-              this.$emit('change', src);
-              this.$emit('handlePreview', true, src);
-            });
-            URL.revokeObjectURL(imageURL);
-          })
-          .catch((error) => {
-            alert('アップロードに失敗しました');
-            console.log(error);
-          });
-      } else {
-        this.$emit('change', null);
-        this.$emit('handlePreview', false, null);
-      }
     },
   },
 };

--- a/app/frontend/components/parts/formInputs/ImagesField.vue
+++ b/app/frontend/components/parts/formInputs/ImagesField.vue
@@ -1,0 +1,64 @@
+<template>
+  <ValidationProvider
+    v-slot="{ errors }"
+    ref="fileForm"
+    name="投稿写真"
+    mode="change"
+    :rules="rules"
+  >
+    <v-file-input
+      id="arrangement-images"
+      label="投稿写真"
+      color="black"
+      clearable
+      hint="有効なファイル形式はjpg jpeg png gifです"
+      prependIcon
+      prependInnerIcon="mdi-camera"
+      persistentHint
+      :errorMessages="errors"
+      @change="handleFileChange"
+    >
+      <template #selection="{ text }">
+        <v-chip small label color="grey lighten-1">
+          {{ text }}
+        </v-chip>
+      </template>
+    </v-file-input>
+  </ValidationProvider>
+</template>
+
+<script>
+import Jimp from 'jimp/es';
+
+export default {
+  props: {
+    rules: {
+      type: Object,
+      required: true,
+    },
+  },
+  methods: {
+    async handleFileChange(value) {
+      const result = await this.$refs.fileForm.validate(value);
+      if (result.valid) {
+        const imageURL = URL.createObjectURL(value);
+        Jimp.read(imageURL)
+          .then((image) => {
+            image.cover(300, 300).getBase64(Jimp.MIME_PNG, (err, src) => {
+              this.$emit('change', src);
+              this.$emit('handlePreview', true, src);
+            });
+            URL.revokeObjectURL(imageURL);
+          })
+          .catch((error) => {
+            alert('アップロードに失敗しました');
+            console.log(error);
+          });
+      } else {
+        this.$emit('change', null);
+        this.$emit('handlePreview', false, null);
+      }
+    },
+  },
+};
+</script>

--- a/app/frontend/components/parts/formInputs/TitleField.vue
+++ b/app/frontend/components/parts/formInputs/TitleField.vue
@@ -1,0 +1,32 @@
+<template>
+  <ValidationProvider v-slot="{ errors }" :rules="rules" name="タイトル">
+    <v-text-field
+      id="arrangement-title"
+      class="mb-6"
+      type="text"
+      label="タイトル"
+      clearable
+      color="black"
+      counter="30"
+      :errorMessages="errors"
+      :value="title"
+      @input="$emit('input', $event)"
+    />
+  </ValidationProvider>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      requird: false,
+      default: null,
+    },
+    rules: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/app/frontend/components/parts/forms/ArrangementEditForm.vue
+++ b/app/frontend/components/parts/forms/ArrangementEditForm.vue
@@ -1,0 +1,134 @@
+<template>
+  <v-dialog :value="isShow" width="650px" @click:outside="closeDialog">
+    <v-sheet id="arranement-edit-form" class="pa-10" color="#eeeeee" :rounded="true">
+      <div class="text-center mb-5">
+        <v-img class="mx-auto mb-5" :src="images[0]" width="70%" style="border-radius: 15px" />
+        <div>
+          <v-btn @click="actionInputFile">変更</v-btn>
+        </div>
+      </div>
+      <ValidationProvider
+        v-slot="{ errors }"
+        ref="fileForm"
+        name="投稿写真"
+        mode="change"
+        :rules="rules.images"
+      >
+        <v-file-input
+          id="arrangement-images"
+          label="投稿写真"
+          style="display: none"
+          @change="handleFileChange"
+        />
+        <v-alert :value="fileErrorDisplayed" type="error" dense outlined :icon="false">
+          {{ errors[0] }}
+        </v-alert>
+      </ValidationProvider>
+      <ValidationObserver ref="form" v-slot="{ handleSubmit }">
+        <TitleField :title="title" :rules="rules.title" @input="$emit('update:title', $event)" />
+        <ContextField
+          :context="context"
+          :rules="rules.context"
+          @input="$emit('update:context', $event)"
+        />
+        <div class="text-center">
+          <v-btn
+            class="mx-2"
+            xLarge
+            style="color: white"
+            color="#ff5252"
+            @click="handleSubmit(handleUpdateArrangement)"
+          >
+            更新
+          </v-btn>
+          <v-btn class="mx-2" xLarge @click="closeDialog">戻る</v-btn>
+        </div>
+      </ValidationObserver>
+    </v-sheet>
+  </v-dialog>
+</template>
+
+<script>
+import Jimp from 'jimp/es';
+import TitleField from '../formInputs/TitleField';
+import ContextField from '../formInputs/ContextField';
+
+export default {
+  components: {
+    TitleField,
+    ContextField,
+  },
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    context: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    images: {
+      type: Array,
+      required: false,
+      default: null,
+    },
+    isShow: {
+      type: Boolean,
+    },
+  },
+  data() {
+    return {
+      rules: {
+        images: { ext: ['jpg', 'jpeg', 'png', 'gif'], size: 10240 },
+        title: { required: true, max: 30 },
+        context: { required: true, max: 1000 },
+      },
+      fileErrorDisplayed: false,
+    };
+  },
+  methods: {
+    actionInputFile() {
+      document.querySelector('#arrangement-images').click();
+    },
+    async handleFileChange(value) {
+      const result = await this.$refs.fileForm.validate(value);
+      if (result.valid) {
+        this.hideErrorMessage();
+        const imageURL = URL.createObjectURL(value);
+        Jimp.read(imageURL)
+          .then((image) => {
+            image.cover(300, 300).getBase64(Jimp.MIME_PNG, (err, src) => {
+              this.$emit('uploadFile', src);
+            });
+            URL.revokeObjectURL(imageURL);
+          })
+          .catch((error) => {
+            alert('アップロードに失敗しました');
+            console.log(error);
+          });
+      } else {
+        this.fileErrorDisplayed = true;
+      }
+    },
+    handleUpdateArrangement() {
+      this.hideErrorMessage();
+      this.$emit('updateArrangement');
+    },
+    closeDialog() {
+      this.hideErrorMessage();
+      this.$emit('closeDialog');
+    },
+    hideErrorMessage() {
+      // バリデーション失敗後だと、エラーメッセージが残ってしまう為
+      this.$refs.fileForm.reset();
+      this.fileErrorDisplayed = false;
+    },
+  },
+};
+</script>

--- a/app/frontend/components/parts/forms/ArrangementNewForm.vue
+++ b/app/frontend/components/parts/forms/ArrangementNewForm.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <v-img v-show="isPreview" class="mb-5" :src="previewImage" contain height="300" />
+    <ValidationObserver v-slot="{ handleSubmit }">
+      <v-card-text>
+        <ImagesField
+          :rules="rules.images"
+          @change="$emit('uploadFile', $event)"
+          @handlePreview="handlePreview"
+        />
+        <TitleField :title="title" :rules="rules.title" @input="$emit('update:title', $event)" />
+        <ContextField
+          :context="context"
+          :rules="rules.context"
+          @input="$emit('update:context', $event)"
+        />
+      </v-card-text>
+      <v-card-actions class="d-flex justify-center">
+        <v-btn
+          style="color: white"
+          color="#ff5252"
+          xLarge
+          :loading="isLoading"
+          :disabled="isLoading"
+          @click="handleSubmit(handleCreateArrangement)"
+        >
+          <v-icon class="mr-1">mdi-send</v-icon>
+          投稿する
+        </v-btn>
+      </v-card-actions>
+    </ValidationObserver>
+  </div>
+</template>
+
+<script>
+import TitleField from '../formInputs/TitleField';
+import ContextField from '../formInputs/ContextField';
+import ImagesField from '../formInputs/ImagesField';
+
+export default {
+  components: {
+    TitleField,
+    ContextField,
+    ImagesField,
+  },
+  props: {
+    title: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    context: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    images: {
+      type: Array,
+      required: false,
+      default: null,
+    },
+    isLoading: {
+      type: Boolean,
+    },
+  },
+  data() {
+    return {
+      rules: {
+        images: { required: true, ext: ['jpg', 'jpeg', 'png', 'gif'], size: 10240 },
+        title: { required: true, max: 30 },
+        context: { required: true, max: 1000 },
+      },
+      previewImage: '',
+      isPreview: false,
+    };
+  },
+  methods: {
+    handleCreateArrangement() {
+      this.$emit('createArrangement');
+    },
+    handlePreview(boolean, src) {
+      this.isPreview = boolean;
+      this.previewImage = src;
+    },
+  },
+};
+</script>

--- a/app/frontend/components/parts/forms/PasswordEditForm.vue
+++ b/app/frontend/components/parts/forms/PasswordEditForm.vue
@@ -65,6 +65,7 @@ export default {
   },
   methods: {
     handleUpdatePassword() {
+      this.$refs.form.reset();
       this.$emit('updatePassword');
     },
     changeDialog() {

--- a/app/frontend/plugins/devour.js
+++ b/app/frontend/plugins/devour.js
@@ -35,10 +35,17 @@ jsonApi.define('arrangement', {
 const requestMiddleware = {
   req: (payload) => {
     if (['POST', 'PATCH'].includes(payload.req.method)) {
-      const model_name = payload.req.model;
-      const data = payload.req.data.data.attributes;
-      payload.req.data = {};
-      payload.req.data[model_name] = data;
+      // devourのcreate,updateメソッドを使う場合
+      if (payload.req.model) {
+        const model_name = payload.req.model;
+        const data = payload.req.data.data.attributes;
+        payload.req.data = {};
+        payload.req.data[model_name] = data;
+      } else {
+        // requestメソッドを使う場合
+        const data = payload.req.data.data;
+        payload.req.data = data;
+      }
     }
     return payload;
   },

--- a/app/frontend/plugins/devour.js
+++ b/app/frontend/plugins/devour.js
@@ -9,6 +9,7 @@ jsonApi.headers['X-CSRF-TOKEN'] = csrfToken();
 jsonApi.headers['CONTENT-TYPE'] = 'application/json';
 
 jsonApi.define('user', {
+  id: '',
   nickname: '',
   email: '',
   avatar: '',
@@ -21,6 +22,7 @@ jsonApi.define('user', {
 });
 
 jsonApi.define('arrangement', {
+  id: '',
   title: '',
   context: '',
   images: [],
@@ -29,5 +31,19 @@ jsonApi.define('arrangement', {
     type: 'user',
   },
 });
+
+const requestMiddleware = {
+  req: (payload) => {
+    if (['POST', 'PATCH'].includes(payload.req.method)) {
+      const model_name = payload.req.model;
+      const data = payload.req.data.data.attributes;
+      payload.req.data = {};
+      payload.req.data[model_name] = data;
+    }
+    return payload;
+  },
+};
+
+jsonApi.insertMiddlewareBefore('axios-request', requestMiddleware);
 
 export default jsonApi;

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -3,7 +3,9 @@ import VueRouter from 'vue-router';
 import store from '../store/index';
 
 import TopPage from '../components/pages/TopPage.vue';
+import Arrangements from '../components/pages/Arrangements.vue';
 import ArrangementNew from '../components/pages/ArrangementNew.vue';
+import ArrangementShow from '../components/pages/ArrangementShow.vue';
 import UserProfile from '../components/pages/UserProfile.vue';
 import UserRegister from '../components/pages/UserRegister.vue';
 import UserLogin from '../components/pages/UserLogin.vue';
@@ -15,30 +17,42 @@ const router = new VueRouter({
   routes: [
     {
       path: '/',
-      component: TopPage,
       name: 'TopPage',
+      component: TopPage,
     },
     {
       path: '/register',
-      component: UserRegister,
       name: 'UserRegister',
+      component: UserRegister,
     },
     {
       path: '/login',
-      component: UserLogin,
       name: 'UserLogin',
+      component: UserLogin,
     },
     {
       path: '/profile',
-      component: UserProfile,
       name: 'UserProfile',
+      component: UserProfile,
       meta: { requireAuth: true },
     },
     {
-      path: '/arrangements/new',
-      component: ArrangementNew,
-      name: 'ArrangementNew',
-      meta: { requireAuth: true },
+      path: '/arrangements',
+      component: Arrangements,
+      children: [
+        {
+          path: 'new',
+          name: 'ArrangementNew',
+          component: ArrangementNew,
+          meta: { requireAuth: true },
+        },
+        {
+          path: ':id',
+          name: 'ArrangementShow',
+          component: ArrangementShow,
+          meta: { requireAuth: true },
+        },
+      ],
     },
   ],
 });
@@ -46,10 +60,10 @@ const router = new VueRouter({
 router.beforeEach((to, from, next) => {
   if (to.matched.some((record) => record.meta.requireAuth)) {
     store.dispatch('users/fetchAuthUser').then((authUser) => {
-      if (!authUser) {
-        next({ name: 'UserLogin' });
-      } else {
+      if (to.name === 'ArrangementShow' || authUser) {
         next();
+      } else {
+        next({ name: 'UserLogin' });
       }
     });
   } else {

--- a/app/frontend/store/modules/users.js
+++ b/app/frontend/store/modules/users.js
@@ -18,8 +18,8 @@ const actions = {
   async registerUser({ commit }, user) {
     try {
       const userResponse = await devour.create('user', user);
-      commit('setAuthUser', userResponse);
-      return userResponse;
+      commit('setAuthUser', userResponse.data);
+      return userResponse.data;
     } catch (err) {
       console.log(err);
       return null;
@@ -47,9 +47,14 @@ const actions = {
   },
   async updateAuthUser({ commit }, user) {
     try {
-      const res = await devour.request(`${devour.apiUrl}/profile`, 'PATCH', {}, { user: user });
-      commit('setAuthUser', res.data);
-      return res.data;
+      const userResponse = await devour.request(
+        `${devour.apiUrl}/profile`,
+        'PATCH',
+        {},
+        { user: user }
+      );
+      commit('setAuthUser', userResponse.data);
+      return userResponse.data;
     } catch (err) {
       console.log(err);
       return null;

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,46 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "33b69bff77018cc135bf208438ae78951b12cef333141e792ebd8ec9b5c5df12",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `Arrangement#find`",
+      "file": "app/controllers/api/arrangements_controller.rb",
+      "line": 26,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "Arrangement.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::ArrangementsController",
+        "method": "show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "dc62d4394650aafbd8e9905f85251f6dc52145be3319f2f652b3b69e35e85f9d",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `Arrangement#find`",
+      "file": "app/controllers/api/arrangements_controller.rb",
+      "line": 36,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "Arrangement.find(params[:arrangement][:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::ArrangementsController",
+        "method": "update"
+      },
+      "user_input": "params[:arrangement][:id]",
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2021-03-24 11:39:35 +0900",
+  "brakeman_version": "5.0.0"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
       patch 'password', on: :member
     end
     resource :session, only: %i[create destroy]
-    resources :arrangements, only: %i[index create] do
+    resources :arrangements, only: %i[index create show update] do
       get 'mine', on: :collection
     end
     get 'validations/unique', to: 'validations#unique'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include UserLogin
 end

--- a/spec/support/user_login.rb
+++ b/spec/support/user_login.rb
@@ -1,0 +1,8 @@
+module UserLogin
+  def log_in_as(user)
+    visit '/login'
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: 'password'
+    click_on 'メールアドレスでログイン'
+  end
+end

--- a/spec/system/user_logins_spec.rb
+++ b/spec/system/user_logins_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe "ユーザーログイン", type: :system, js: true do
+  let(:user) { create(:user, email: 'example@examle.com') }
+
+  before do
+    user
+    visit '/login'
+  end
+
+  describe 'フロント側のバリデーション機能' do
+    describe '必須項目の検証' do
+      context '必須欄が全て未入力の場合' do
+        before { click_on 'メールアドレスでログイン' }
+        it 'エラーメッセージ「<ラベル名>は必須項目です」が表示される' do
+          aggregate_failures do
+            expect(page).to have_content 'メールアドレスは必須項目です'
+            expect(page).to have_content 'パスワードは必須項目です'
+          end
+        end
+      end
+    end
+
+    describe '文字数の検証' do
+      context 'アドレスが51文字、パスワードが5文字の場合' do
+        before do
+          fill_in 'メールアドレス', with: 'a' * 39 + '@example.com'
+          fill_in 'パスワード', with: 'a' * 5
+          click_on 'メールアドレスでログイン'
+        end
+        it '文字数に関するエラーメッセージが表示される' do
+          aggregate_failures do
+            expect(page).to have_content 'メールアドレスは50文字以内にしてください'
+            expect(page).to have_content 'パスワードは6文字以上でなければなりません'
+          end
+        end
+      end
+    end
+
+    describe 'フォーマットの検証' do
+      context 'アドレスが不適当な場合' do
+        invalid_addresses = %w[user@example,com USER.foo.COM A_US-ER@foo. foo@bar_foo.jp foo@bar+baz.com foo@bar..com foo\ bar@baz.com]
+        it '「有効なメールアドレスではありません」と表示される' do
+          invalid_addresses.each do |invalid_address|
+            fill_in 'メールアドレス', with: invalid_address
+            click_on 'メールアドレスでログイン'
+            expect(page).to have_content '有効なメールアドレスではありません'
+          end
+        end
+      end
+
+      context 'パスワードが不適当な場合' do
+        invalid_passwords = %w[ｐａｓsｗｏrd あいうえおか １２３４５６ foo..bar @//#bar foo\ bar]
+        it '「パスワードのフォーマットが正しくありません」と表示される' do
+          invalid_passwords.each do |invalid_password|
+            fill_in 'パスワード', with: invalid_password
+            click_on 'メールアドレスでログイン'
+            expect(page).to have_content 'パスワードのフォーマットが正しくありません'
+          end
+        end
+      end
+    end
+  end
+
+  context 'ログイン情報が間違っている場合' do
+    before do
+      fill_in 'メールアドレス', with: 'foobar@foobar.com'
+      fill_in 'パスワード', with: 'foobar'
+      click_on 'メールアドレスでログイン'
+    end
+    it '「ログインに失敗しました」と表示される' do
+      within '#global-snackbar' do
+        expect(page).to have_content 'ログインに失敗しました'
+      end
+      expect(current_path).to eq '/login'
+    end
+  end
+
+  context 'ログイン情報が正しい場合' do
+    before do
+      fill_in 'メールアドレス', with: 'example@examle.com'
+      fill_in 'パスワード', with: 'password'
+      click_on 'メールアドレスでログイン'
+    end
+    it 'トップページへ遷移し、「ログインしました」と表示される' do
+      within '#global-snackbar' do
+        expect(page).to have_content 'ログインしました'
+      end
+      expect(current_path).to eq '/'
+    end
+    it 'ヘッダーのログインボタンが非表示になっている' do
+      sleep 0.5
+      expect(page).to have_no_link 'ログイン'
+    end
+  end
+
+  describe 'ログインページへの導線確認' do
+    context 'ヘッダーの「ログイン」をクリックした時' do
+      before do
+        click_on 'ログイン'
+      end
+      it 'ログインページへ遷移する' do
+        expect(current_path).to eq '/login'
+      end
+    end
+
+    context '新規登録ページにある「既にアカウントをお持ちの方はこちらから。」をクリックした時' do
+      before {
+        visit '/register'
+        click_on 'こちら'
+      }
+      it 'ログインページへ遷移する' do
+        expect(current_path).to eq '/login'
+      end
+    end
+  end
+end

--- a/spec/system/user_logouts_spec.rb
+++ b/spec/system/user_logouts_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "UserLogouts", type: :system, js: true do
+  let(:user) { create(:user) }
+
+  before do
+    log_in_as(user)
+    find('#header-avatar').click
+  end
+
+  it 'ヘッダーのメニューリスト内に「ログアウト」が表示されている' do
+    within '#header-menu-list' do
+      aggregate_failures do
+        expect(page).to have_content 'ログアウト'
+        expect(page.has_css?('#header-logout-button')).to eq true
+      end
+    end
+  end
+
+  context '「ログアウト」をクリックした時' do
+    before do
+      within '#header-menu-list' do
+        find('#header-logout-button').click
+      end
+    end
+
+    it 'ヘッダーのメニューリスト内の「ログアウト」は非表示になっている' do
+      aggregate_failures do
+        expect(page).to have_no_content 'ログアウト'
+        expect(page.has_no_css?('#header-logout-button')).to eq true
+      end
+    end
+  end
+end

--- a/spec/system/user_registers_spec.rb
+++ b/spec/system/user_registers_spec.rb
@@ -1,13 +1,118 @@
 require 'rails_helper'
 
 RSpec.describe "ユーザー登録", type: :system, js: true do
-  # context 'ユーザー情報に不備がある場合' do
-  #   before do
-  #     visit '/register'
-  #     click_on 'メールアドレスで登録'
-  #   end
-  #   it '新規登録に失敗する' do
-  #     expect(page).to have_content 'ニックネームは必須項目です'
-  #   end
-  # end
+  before { visit '/register' }
+
+  describe 'フロント側のバリーデーション機能' do
+    describe '必須項目の検証' do
+      context '必須欄が全て未入力の場合' do
+        before { click_on 'メールアドレスで登録' }
+        it 'エラーメッセージ「<ラベル名>は必須項目です」が表示される' do
+          aggregate_failures do
+            expect(page).to have_content 'ニックネームは必須項目です'
+            expect(page).to have_content 'メールアドレスは必須項目です'
+            expect(page).to have_content 'パスワードは必須項目です'
+            expect(page).to have_content 'パスワード(確認用)は必須項目です'
+          end
+        end
+      end
+    end
+
+    describe '一意性の検証' do
+      context '使用されているニックネーム、アドレスを使用した場合' do
+        before do
+          create(:user, nickname: 'mimata', email: 'mimata@mimata.com')
+          fill_in 'ニックネーム', with: 'mimata'
+          fill_in 'メールアドレス', with: 'mimata@mimata.com'
+          click_on 'メールアドレスで登録'
+        end
+        it 'エラーメッセージ「<value>は既に使われています」が表示される' do
+          expect(page).to have_content 'mimataは既に使われています'
+          expect(page).to have_content 'mimata@mimata.comは既に使われています'
+        end
+      end
+    end
+
+    describe '文字数の検証' do
+      context 'ニックネームが31文字、アドレスが51文字、パスワードが5文字の場合' do
+        before do
+          fill_in 'ニックネーム', with: 'a' * 31
+          fill_in 'メールアドレス', with: 'a' * 39 + '@example.com'
+          fill_in 'パスワード', with: 'a' * 5
+          fill_in 'パスワード(確認用)', with: 'a' * 5
+          click_on 'メールアドレスで登録'
+        end
+        it '文字数に関するエラーメッセージが表示される' do
+          aggregate_failures do
+            expect(page).to have_content 'ニックネームは30文字以内にしてください'
+            expect(page).to have_content 'メールアドレスは50文字以内にしてください'
+            expect(page).to have_content 'パスワードは6文字以上でなければなりません'
+          end
+        end
+      end
+    end
+
+    describe 'フォーマットの検証' do
+      context 'アドレスが不適当な場合' do
+        invalid_addresses = %w[user@example,com USER.foo.COM A_US-ER@foo. foo@bar_foo.jp foo@bar+baz.com foo@bar..com foo\ bar@baz.com]
+        it '「有効なメールアドレスではありません」と表示される' do
+          invalid_addresses.each do |invalid_address|
+            fill_in 'メールアドレス', with: invalid_address
+            click_on 'メールアドレスで登録'
+            expect(page).to have_content '有効なメールアドレスではありません'
+          end
+        end
+      end
+
+      context 'パスワードが不適当な場合' do
+        invalid_passwords = %w[ｐａｓsｗｏrd あいうえおか １２３４５６ foo..bar @//#bar foo\ bar]
+        it '「パスワードのフォーマットが正しくありません」と表示される' do
+          invalid_passwords.each do |invalid_password|
+            fill_in 'パスワード', with: invalid_password
+            click_on 'メールアドレスで登録'
+            expect(page).to have_content 'パスワードのフォーマットが正しくありません'
+          end
+        end
+      end
+    end
+
+    describe '確認用(パスワード)の検証' do
+      context 'パスワード、パスワード(確認用)の入力値が異なる場合' do
+        before do
+          fill_in 'パスワード', with: 'a' * 10
+          fill_in 'パスワード(確認用)', with: 'b' * 10
+          click_on 'メールアドレスで登録'
+        end
+        it '「パスワード(確認用)が一致しません」と表示される' do
+          expect(page).to have_content 'パスワード(確認用)が一致しません'
+        end
+      end
+    end
+  end
+
+  context '適当な値を入力している場合' do
+    before do
+      fill_in 'ニックネーム', with: 'mimata'
+      fill_in 'メールアドレス', with: 'example@example.com'
+      fill_in 'パスワード', with: 'password'
+      fill_in 'パスワード(確認用)', with: 'password'
+      click_on 'メールアドレスで登録'
+    end
+    it '新規登録後に「投稿ページへ」ボタンが表示され、クリックすると投稿ページへ遷移する' do
+      within '#welcome-dialog' do
+        expect(current_path).to eq '/'
+        expect(page).to have_link '投稿ページへ', href: '/arrangements/new'
+        click_on '投稿ページへ'
+      end
+      expect(current_path).to eq '/arrangements/new'
+    end
+    it '新規登録後に「あとで」ボタンが表示され、クリックするとダイアログが閉じる' do
+      within '#welcome-dialog' do
+        expect(page).to have_button 'あとで'
+        click_on 'あとで'
+      end
+      sleep 0.5
+      expect(page.has_selector?('#welcome-dialog')).to eq false
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- 投稿カードをクリックすると、投稿詳細ページへ遷移する。
- 投稿詳細ページに「編集」ボタンを設置し、クリックすると編集用のダイアログが表示される。

## 詳細
### ①詳細ページの作成
- urlは「/arrangements/:id」とする。
- トップページ、もしくはプロフィールページにある投稿をクリックすると、投稿詳細ページへ遷移する。
- 詳細ページへはログイン前でもアクセスできる。
[![Image from Gyazo](https://i.gyazo.com/f31ac5dda8a22c2a7940b3e691fe039e.gif)](https://gyazo.com/f31ac5dda8a22c2a7940b3e691fe039e)

- 詳細ページには「投稿のタイトル、内容、投稿画像、投稿者の名前、プロフィール画像」が表示されている。
[![Image from Gyazo](https://i.gyazo.com/f0af1c2b107bc15d7d6ec7bf1df2b0cd.jpg)](https://gyazo.com/f0af1c2b107bc15d7d6ec7bf1df2b0cd)

### ②編集機能の作成
- 自分の投稿のみ「編集」ボタンが表示される。
[![Image from Gyazo](https://i.gyazo.com/62863a9727c671a1619eeea7f596bb84.png)](https://gyazo.com/62863a9727c671a1619eeea7f596bb84)

- 「編集」ボタンをクリックすると、編集用のダイアログが表示される。
- 「タイトル、投稿内容、投稿画像」が編集できる。
[![Image from Gyazo](https://i.gyazo.com/941ca54d8cb2bcadb3bf01a84258e981.jpg)](https://gyazo.com/941ca54d8cb2bcadb3bf01a84258e981)

