### PR TITLE
サーバー側のエラーハンドリングを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Style/Documentation:
 
 Style/AsciiComments:
   Enabled: false
+
+Naming/VariableNumber:
+  Enabled: :snake_case

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'carrierwave', '~> 2.0'
 # pagination
 gem 'pagy', '~> 3.5'
 
+# I18n
+gem 'rails-i18n', '~> 6.0.0'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_best_practices (1.20.0)
       activesupport
       code_analyzer (>= 0.5.1)
@@ -348,6 +351,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
+  rails-i18n (~> 6.0.0)
   rails_best_practices
   rspec-rails (~> 4.0.2)
   rubocop (~> 1.10)

--- a/app/controllers/api/arrangements_controller.rb
+++ b/app/controllers/api/arrangements_controller.rb
@@ -16,12 +16,9 @@ module Api
 
     def create
       arrangement = current_user.arrangements.build(arrangement_params)
-      if arrangement.save
-        json_string = ArrangementSerializer.new(arrangement).serializable_hash
-        render json: json_string
-      else
-        render json: arrangement.errors.full_messages, status: :bad_request
-      end
+      arrangement.save!
+      json_string = ArrangementSerializer.new(arrangement).serializable_hash
+      render json: json_string
     end
 
     def show
@@ -34,7 +31,7 @@ module Api
     end
 
     def update
-      render head 400 unless @arrangement.update(arrangement_params)
+      @arrangement.update!(arrangement_params)
       options = {
         include: %i[user],
         fields: { arrangement: %i[title context images user], user: %i[nickname avatar] }
@@ -45,7 +42,7 @@ module Api
 
     def destroy
       @arrangement.destroy!
-      head 200
+      head :no_content
     end
 
     def mine

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -1,17 +1,15 @@
 module Api
   class ProfilesController < ApplicationController
     def update
-      if current_user.update(user_params)
-        json_string = UserSerializer.new(current_user).serializable_hash
-        render json: json_string
-      else
-        head 400
-      end
+      current_user.update!(user_params)
+      json_string = UserSerializer.new(current_user).serializable_hash
+      render json: json_string
     end
 
     def password
       current_user.password_confirmation = params[:password_confirmation]
-      current_user.change_password(params[:password]) ? head(200) : head(400)
+      current_user.change_password!(params[:password])
+      head 200
     end
 
     private

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -4,17 +4,15 @@ module Api
 
     def create
       user = login(params[:email], params[:password])
-      if user
-        json_string = UserSerializer.new(user).serializable_hash
-        render json: json_string
-      else
-        head :unauthorized
-      end
+      raise ActiveRecord::RecordNotFound unless user
+
+      json_string = UserSerializer.new(user).serializable_hash
+      render json: json_string
     end
 
     def destroy
       logout
-      head 200
+      head :no_content
     end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -6,13 +6,10 @@ module Api
 
     def create
       user = User.new(user_params)
-      if user.save
-        auto_login(user)
-        json_string = UserSerializer.new(user).serializable_hash
-        render json: json_string
-      else
-        head 400
-      end
+      user.save!
+      auto_login(user)
+      json_string = UserSerializer.new(user).serializable_hash
+      render json: json_string
     end
 
     def me

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,11 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
   include Api::CreateUploadedfile
+  include Api::ExceptionHandring
+
+  private
+
+  def not_authenticated
+    render_400(nil, 'ログインしてください')
+  end
 end

--- a/app/controllers/concerns/api/exception_handring.rb
+++ b/app/controllers/concerns/api/exception_handring.rb
@@ -1,0 +1,33 @@
+module Api
+  module ExceptionHandring
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from StandardError, with: :render_500
+      rescue_from ActiveRecord::RecordNotFound, with: :render_404
+      rescue_from ActiveRecord::RecordInvalid, with: :render_400
+    end
+
+    private
+
+    def render_500(exception = nil, messages = nil)
+      render_error(:internal_server_error, 'Internal Server Error', exception&.message, *messages)
+    end
+
+    def render_404(exception = nil, messages = nil)
+      render_error(:not_found, 'Record Not Found', exception&.message, *messages)
+    end
+
+    def render_400(exception = nil, messages = nil)
+      render_error(:bad_request, 'Bad Request', exception&.message, *messages)
+    end
+
+    def render_error(status, message, *detail)
+      error_response = {
+        message: message,
+        detail: detail.compact
+      }
+      render json: error_response, status: status
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,8 +42,6 @@ module Arrangy
     end
 
     config.generators.system_tests = nil
-    # [en]の利用を許可しないとFackerを使用した際に、errorを吐く
-    config.i18n.available_locales = %i[ja en]
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"
     config.active_record.default_timezone = :local

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module Arrangy
 
     config.generators.system_tests = nil
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.time_zone = "Asia/Tokyo"
     config.active_record.default_timezone = :local
     #https://github.com/jsonapi-serializer/jsonapi-serializer/pull/141

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      arrangement: '投稿'
+    attributes:
+      user:
+        nickname: 'ニックネーム'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード(確認用)'
+        avatar: 'アバター'
+      arrangement:
+        title: 'タイトル'
+        context: '投稿内容'
+        images: '投稿写真'


### PR DESCRIPTION
## 詳細
- サーバーエラー(StandardErrorで補足できるもの)は、500エラー(internal server error)を返す。
- レコードが見つからない場合は、404エラー(not found)を返す。
- バリデーションエラーの場合は、400エラー(bad request)を返す。
- before_action「require_login」で認証に失敗した場合のロジックを追加。
  「not_authenticated」メソッドを追加し、400エラーを返すように実装する。