### PR TITLE
管理画面(ユーザー一覧、投稿一覧)の作成

### DIFF
--- a/app/controllers/api/admin/arrangements_controller.rb
+++ b/app/controllers/api/admin/arrangements_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module Admin
+    class ArrangementsController < BaseController
+      def index
+        pagy, arrangements = pagy(Arrangement.preload(:user), items: 20)
+        options = {
+          include: %i[user],
+          fields: {
+            arrangement: %i[title images created_at likes_count comments_count user],
+            user: %i[nickname]
+          },
+          meta: { pagy: pagy_metadata(pagy) }
+        }
+        render_serializer(arrangements, options)
+      end
+
+      private
+
+      def render_serializer(arrangement, options = {})
+        json_string = ArrangementSerializer.new(arrangement, options)
+        render json: json_string
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/auth_users_controller.rb
+++ b/app/controllers/api/admin/auth_users_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module Admin
+    class AuthUsersController < BaseController
+      skip_before_action :require_login, only: %i[create show]
+
+      def create
+        user = login(params[:email], params[:password])
+        return render_400 unless user&.admin?
+
+        options = { fields: { user: %i[nickname email avatar role] } }
+        render_serializer(user, options)
+      end
+
+      def show
+        options = { fields: { user: %i[nickname email avatar role] } }
+        render_serializer(current_user, options)
+      end
+
+      def destroy
+        session[:user_id] = nil
+        current_user = nil # rubocop:disable Lint/UselessAssignment
+        head :no_content
+      end
+
+      private
+
+      def render_serializer(user, options = {})
+        json_string = UserSerializer.new(user, options)
+        render json: json_string
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/base_controller.rb
+++ b/app/controllers/api/admin/base_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module Admin
+    class BaseController < ApplicationController
+      private
+
+      def require_login
+        return render_401(nil, '管理者権限がありません') unless current_user.admin?
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module Admin
+    class UsersController < BaseController
+      def index
+        pagy, users = pagy(User.all, items: 20)
+        options = {
+          fields: {
+            user: %i[nickname email avatar role created_at]
+          },
+          meta: { pagy: pagy_metadata(pagy) }
+        }
+        render_serializer(users, options)
+      end
+
+      private
+
+      def render_serializer(user, options = {})
+        json_string = UserSerializer.new(user, options)
+        render json: json_string
+      end
+    end
+  end
+end

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -1,10 +1,8 @@
 <template>
   <v-app>
     <v-main class="base-color">
-      <template v-if="responseState.state === 'error'">
-        <NotFound v-if="responseState.status === 404" />
-        <ServerError v-else-if="responseState.status === 500" />
-      </template>
+      <NotFound v-if="responseState.status === 404" />
+      <ServerError v-else-if="responseState.status === 500" />
       <template v-else>
         <router-view name="header" />
         <router-view name="snackbar" />

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -1,15 +1,17 @@
 <template>
   <v-app>
-    <router-view v-if="responseState.state !== 'error'" name="header" />
     <v-main class="base-color">
-      <NotFound v-if="responseState.status === 404" />
-      <ServerError v-else-if="responseState.status === 500" />
+      <template v-if="responseState.state === 'error'">
+        <NotFound v-if="responseState.status === 404" />
+        <ServerError v-else-if="responseState.status === 500" />
+      </template>
       <template v-else>
+        <router-view name="header" />
         <router-view name="snackbar" />
         <router-view class="py-15" />
+        <router-view name="footer" />
       </template>
     </v-main>
-    <router-view v-if="responseState.state !== 'error'" name="footer" />
   </v-app>
 </template>
 

--- a/app/frontend/components/global/admin/AdminHeader.vue
+++ b/app/frontend/components/global/admin/AdminHeader.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <v-app-bar id="page-header" fixed height="60" elevation="1" class="px-md-10" color="#FAFAFA">
+      <v-app-bar-nav-icon @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
+      <v-toolbar-title> 管理画面 </v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn text outlined @click="handleLogout">ログアウト</v-btn>
+    </v-app-bar>
+
+    <v-navigation-drawer v-model="drawer" temporary absolute>
+      <v-list nav dense>
+        <v-list-item-group v-model="group">
+          <v-list-item class="px-2">
+            <v-list-item-avatar>
+              <v-img :src="adminUser.avatar" />
+            </v-list-item-avatar>
+          </v-list-item>
+          <v-list-item link>
+            <v-list-item-content>
+              <v-list-item-title class="title"> {{ adminUser.nickname }} </v-list-item-title>
+              <v-list-item-subtitle>{{ adminUser.email }}</v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-divider class="mb-5" />
+
+          <v-list-item :to="{ name: 'AdminUsers' }">
+            <v-list-item-icon>
+              <v-icon>mdi-account-multiple</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>ユーザー一覧</v-list-item-title>
+          </v-list-item>
+          <v-list-item :to="{ name: 'AdminArrangements' }">
+            <v-list-item-icon>
+              <v-icon>mdi-file-multiple</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>投稿一覧</v-list-item-title>
+          </v-list-item>
+        </v-list-item-group>
+      </v-list>
+    </v-navigation-drawer>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+export default {
+  data() {
+    return {
+      drawer: false,
+      group: null,
+    };
+  },
+  computed: {
+    ...mapGetters('adminUsers', ['adminUser']),
+  },
+  watch: {
+    group() {
+      return (this.drawer = false);
+    },
+  },
+  methods: {
+    ...mapActions('adminUsers', ['logoutAdmin']),
+    ...mapActions('snackbars', ['fetchSnackbarData']),
+    handleLogout() {
+      this.logoutAdmin().then((res) => {
+        if (res) {
+          this.$router.push({ name: 'AdminLogin' });
+          this.fetchSnackbarData({
+            msg: 'ログアウトしました',
+            color: 'success',
+            isShow: true,
+          });
+        } else {
+          this.fetchSnackbarData({
+            msg: 'ログアウトに失敗しました',
+            color: 'error',
+            isShow: true,
+          });
+        }
+      });
+    },
+  },
+};
+</script>

--- a/app/frontend/components/pages/admin/AdminArrangements.vue
+++ b/app/frontend/components/pages/admin/AdminArrangements.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-container>
+    <v-row class="pt-5">
+      <v-col>
+        <v-data-table
+          :headers="table.headers"
+          :items="arrangements"
+          hideDefaultFooter
+          :itemsPerPage="20"
+        >
+        </v-data-table>
+        <v-pagination
+          v-model="pagy.currentPage"
+          :length="pagy.pageCount"
+          @input="fetchArrangements"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      arrangements: [],
+      pagy: {
+        currentPage: 1,
+        pageCount: null,
+      },
+    };
+  },
+  computed: {
+    table() {
+      return {
+        headers: [
+          {
+            text: 'タイトル',
+            align: 'start',
+            value: 'title',
+          },
+          { text: '投稿日', value: 'created_at' },
+          { text: 'いいね数', value: 'likes_count' },
+          { text: 'コメント数', value: 'comments_count' },
+          { text: '投稿者', value: 'user.nickname' },
+        ],
+      };
+    },
+  },
+  created() {
+    this.fetchArrangements();
+  },
+  methods: {
+    fetchArrangements() {
+      this.$devour
+        .request(`${this.$devour.apiUrl}/admin/arrangements`, 'GET', {
+          page: this.pagy.currentPage,
+        })
+        .then((res) => {
+          this.arrangements = res.data;
+          const pagy = res.meta.pagy;
+          this.pagy.pageCount = pagy.pages;
+        });
+    },
+  },
+};
+</script>

--- a/app/frontend/components/pages/admin/AdminLogin.vue
+++ b/app/frontend/components/pages/admin/AdminLogin.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-container class="fill-height">
+    <v-row class="d-flex justify-center">
+      <v-col cols="12" md="6">
+        <v-card>
+          <ValidationObserver id="login-using-address" v-slot="{ handleSubmit }" tag="form">
+            <v-card-text class="px-8">
+              <EmailField :email="user.email" :rules="rules.email" @input="user.email = $event" />
+              <PasswordField
+                :password="user.password"
+                :rules="rules.password"
+                @input="user.password = $event"
+              />
+            </v-card-text>
+            <v-card-actions class="d-flex justify-center pb-8">
+              <SubmitButton
+                :xLarge="true"
+                :color="'#cc3918'"
+                @submit="handleSubmit(handleLoginAdmin)"
+              >
+                <template #text> 管理画面へログイン </template>
+              </SubmitButton>
+            </v-card-actions>
+          </ValidationObserver>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import EmailField from '../../parts/formInputs/EmailField';
+import PasswordField from '../../parts/formInputs/PasswordField';
+import SubmitButton from '../../parts/buttons/SubmitButton';
+import { mapActions } from 'vuex';
+
+export default {
+  components: {
+    EmailField,
+    PasswordField,
+    SubmitButton,
+  },
+  data() {
+    return {
+      user: {
+        email: '',
+        password: '',
+      },
+    };
+  },
+  computed: {
+    rules() {
+      return {
+        email: { required: true, email: true, max: 50 },
+        password: { required: true, min: 6, regex: /^[0-9a-zA-Z]+$/i },
+      };
+    },
+  },
+  methods: {
+    ...mapActions('adminUsers', ['loginAdmin']),
+    ...mapActions('snackbars', ['fetchSnackbarData']),
+    handleLoginAdmin() {
+      this.loginAdmin(this.user).then((user) => {
+        if (user) {
+          this.$router.push({ name: 'AdminUsers' });
+          this.fetchSnackbarData({
+            msg: 'ログインしました',
+            color: 'success',
+            isShow: true,
+          });
+        } else {
+          this.fetchSnackbarData({
+            msg: 'ログインに失敗しました',
+            color: 'error',
+            isShow: true,
+          });
+        }
+      });
+    },
+  },
+};
+</script>

--- a/app/frontend/components/pages/admin/AdminUsers.vue
+++ b/app/frontend/components/pages/admin/AdminUsers.vue
@@ -1,0 +1,65 @@
+<template>
+  <v-container>
+    <v-row class="pt-5">
+      <v-col>
+        <v-data-table :headers="table.headers" :items="users" hideDefaultFooter :itemsPerPage="20">
+        </v-data-table>
+        <v-pagination v-model="pagy.currentPage" :length="pagy.pageCount" @input="fetchUsers" />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      users: [],
+      pagy: {
+        currentPage: 1,
+        pageCount: null,
+      },
+    };
+  },
+  computed: {
+    table() {
+      return {
+        headers: [
+          {
+            text: '投稿者名',
+            align: 'start',
+            value: 'nickname',
+          },
+          {
+            text: 'アドレス',
+            value: 'email',
+          },
+          {
+            text: '権限',
+            value: 'role',
+          },
+          {
+            text: '登録日',
+            value: 'created_at',
+          },
+        ],
+      };
+    },
+  },
+  created() {
+    this.fetchUsers();
+  },
+  methods: {
+    fetchUsers() {
+      this.$devour
+        .request(`${this.$devour.apiUrl}/admin/users`, 'GET', { pagy: this.pagy.currentPage })
+        .then((res) => {
+          console.log(res.data);
+          this.users = res.data;
+          const pagy = res.meta.pagy;
+          this.pagy.pageCount = pagy.pages;
+        });
+    },
+  },
+};
+</script>

--- a/app/frontend/plugins/devour.js
+++ b/app/frontend/plugins/devour.js
@@ -15,10 +15,12 @@ jsonApi.define('user', {
   nickname: '',
   email: '',
   avatar: '',
+  role: '',
   password: '',
   password_confirmation: '',
   arrangements_count: '',
   likes_count: '',
+  created_at: '',
   arrangements: {
     jsonApi: 'hasMany',
     type: 'arrangements',

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -112,6 +112,34 @@ const router = new VueRouter({
       },
     },
     {
+      path: '/admin/login',
+      name: 'AdminLogin',
+      components: {
+        default: () => import('../components/pages/admin/AdminLogin'),
+        snackbar: () => import('../components/global/TheSnackbar.vue'),
+      },
+    },
+    {
+      path: '/admin/users',
+      name: 'AdminUsers',
+      components: {
+        default: () => import('../components/pages/admin/AdminUsers'),
+        header: () => import('../components/global/admin/AdminHeader'),
+        snackbar: () => import('../components/global/TheSnackbar.vue'),
+      },
+      meta: { requireAdmin: true },
+    },
+    {
+      path: '/admin/arrangements',
+      name: 'AdminArrangements',
+      components: {
+        default: () => import('../components/pages/admin/AdminArrangements'),
+        header: () => import('../components/global/admin/AdminHeader'),
+        snackbar: () => import('../components/global/TheSnackbar.vue'),
+      },
+      meta: { requireAdmin: true },
+    },
+    {
       path: '*',
       name: '404Page',
       component: () => import('../components/pages/error/NotFound.vue'),
@@ -129,6 +157,20 @@ router.beforeEach((to, from, next) => {
         next();
       } else {
         next({ name: 'UserLogin' });
+      }
+    });
+  } else {
+    next();
+  }
+});
+
+router.beforeEach((to, from, next) => {
+  if (to.matched.some((record) => record.meta.requireAdmin)) {
+    store.dispatch('adminUsers/fetchAdminUser').then((adminUser) => {
+      if (adminUser && adminUser.role === 'admin') {
+        next();
+      } else {
+        next({ name: 'AdminLogin' });
       }
     });
   } else {

--- a/app/frontend/store/index.js
+++ b/app/frontend/store/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import adminUsers from './modules/adminUsers';
 import users from './modules/users';
 import snackbars from './modules/snackbars';
 import responseState from './modules/responseState';
@@ -10,6 +11,7 @@ export default new Vuex.Store({
   // eslint-disable-next-line no-undef
   strict: process.env.NODE_ENV !== 'production',
   modules: {
+    adminUsers,
     users,
     responseState,
     snackbars,

--- a/app/frontend/store/modules/adminUsers.js
+++ b/app/frontend/store/modules/adminUsers.js
@@ -1,0 +1,56 @@
+import devour from '../../plugins/devour';
+
+const state = {
+  adminUser: null,
+};
+
+const getters = {
+  adminUser: (state) => state.adminUser,
+};
+
+const mutations = {
+  setAdminUser(state, user) {
+    state.adminUser = user;
+  },
+};
+
+const actions = {
+  async loginAdmin({ commit }, user) {
+    try {
+      const userResponse = await devour.request(
+        `${devour.apiUrl}/admin/auth_user`,
+        'POST',
+        {},
+        user
+      );
+      commit('setAdminUser', userResponse.data);
+      return userResponse.data;
+    } catch (err) {
+      return null;
+    }
+  },
+  async logoutAdmin({ commit }) {
+    try {
+      const res = await devour.request(`${devour.apiUrl}/admin/auth_user`, 'DELETE');
+      commit('setAdminUser', null);
+      return res;
+    } catch (err) {
+      return null;
+    }
+  },
+  async fetchAdminUser({ commit, state }) {
+    if (state.adminUser) return state.adminUser;
+    const userResponse = await devour.request(`${devour.apiUrl}/admin/auth_user`, 'GET');
+    if (!userResponse.data) return null;
+    commit('setAdminUser', userResponse.data);
+    return userResponse.data;
+  },
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions,
+};

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@
 # salt                             string
 # arrangements_count               bigint       default 0
 # likes_count                      bigint       default 0
+# role                             integer      default 0
 # reset_password_token             string
 # reset_password_token_eqpires_at  string
 # reset_password_email_sent_at     datetime
@@ -21,16 +22,19 @@
 
 class User < ApplicationRecord
   has_many :arrangements, dependent: :destroy
-  has_many :comments,     dependent: :destroy
   has_many :authentications, dependent: :destroy
-  accepts_nested_attributes_for :authentications
+  has_many :comments,     dependent: :destroy
   has_many :likes, -> { order(created_at: :desc) }, inverse_of: 'user', dependent: :destroy
   has_many :liking_arrangements, through: :likes, source: :arrangement
+
+  accepts_nested_attributes_for :authentications
 
   before_save :change_email_to_lowercase
 
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader
+
+  enum role: { general: 0, admin: 1 }
 
   VALID_EMAIL_FORMAT = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   VALID_PASSWORD_FORMAT = /\A\w+\z/i.freeze

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,10 +1,13 @@
 class UserSerializer
   include JSONAPI::Serializer
   set_type :user
-  attributes :nickname, :email, :likes_count, :arrangements_count
+  attributes :nickname, :email, :role, :likes_count, :arrangements_count
 
   attribute :avatar do |object|
     object.avatar.url
+  end
+  attribute :created_at do |record|
+    I18n.l(record.created_at, format: :short)
   end
 
   has_many :arrangements

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root 'static_pages#top'
+
   namespace :api, format: 'json' do
     namespace :arrangements do
       resources :favorites, only: :index
@@ -20,11 +22,16 @@ Rails.application.routes.draw do
     post "oauth/callback", to: "oauths#callback"
     get "oauth/callback",  to: "oauths#callback"
     get "oauth/:provider", to: "oauths#oauth", as: :auth_at_provider
+
+    namespace :admin do
+      resource :auth_user, only: %i[create show destroy]
+      resources :arrangements, only: %i[index]
+      resources :users, only: :index
+    end
   end
 
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   get '*path', to: 'static_pages#top'
-  root 'static_pages#top'
 end

--- a/db/fixtures/development/01_user.rb
+++ b/db/fixtures/development/01_user.rb
@@ -2,7 +2,7 @@ FileUtils.rm_rf("#{Rails.root}/public/uploads/user")
 
 User.seed(
   :id,
-  { id: 0, nickname: 'mimata', email: 'mimata@mimata.com', crypted_password: User.encrypt('password') }
+  { id: 0, nickname: 'mimata', email: 'mimata@mimata.com', crypted_password: User.encrypt('password'), role: 1 }
 )
 
 1.upto(4) do |n|

--- a/db/migrate/20210420042528_add_role_to_users.rb
+++ b/db/migrate/20210420042528_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_212420) do
+ActiveRecord::Schema.define(version: 2021_04_20_042528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2021_04_16_212420) do
     t.datetime "reset_password_email_sent_at"
     t.bigint "likes_count", default: 0
     t.bigint "arrangements_count", default: 0
+    t.integer "role", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["nickname"], name: "index_users_on_nickname", unique: true
   end


### PR DESCRIPTION
## 概要
- 管理画面へのログインページの作成
- ユーザー一覧ページの作成
- 投稿一覧ページの作成

## 詳細
### ① 管理画面へのログインページの作成
- usersテーブルに`role`カラムを追加、詳細は下記を参照すること。

| カラム | 型 | 制約 |
| :---: | :---: | :---:|
| role | integer | default 0 |

roleカラムには`enum`を使用する。
```ruby
  enum role: { general: 0, admin: 1 }
```
- ログインページのURLは`/admin/login`とする。

- 完成図
[![Image from Gyazo](https://i.gyazo.com/00052517af0743f5ffbc4eb8bb0b9455.png)](https://gyazo.com/00052517af0743f5ffbc4eb8bb0b9455)

### ② ユーザー一覧ページ/投稿一覧ページの作成
ユーザー一覧ページのURLは`/admin/users`、投稿一覧ページのURLは`/admin/arrangements`とする。

- 完成図
[![Image from Gyazo](https://i.gyazo.com/354210ce4b73e522655d403694e1ff13.png)](https://gyazo.com/354210ce4b73e522655d403694e1ff13)

[![Image from Gyazo](https://i.gyazo.com/979f302a8ba2a46f7072b212a73b4c50.png)](https://gyazo.com/979f302a8ba2a46f7072b212a73b4c50)