### PR TITLE
[Fix] Rails.application.eager_loadを追加

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 require 'simplecov'
 SimpleCov.start 'rails'
-# Rails.application.eager_load!
-
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
テストカバレッジを測定する際、springの影響を受けないようにする為